### PR TITLE
make use of RedisDriver type of redis-smq-monitor

### DIFF
--- a/example/typescript/config.ts
+++ b/example/typescript/config.ts
@@ -1,11 +1,11 @@
-import {ConfigInterface, ConfigRedisDriver} from "../../types/config";
-
+import {ConfigInterface} from "../../types/config";
+import { Monitor } from "redis-smq-monitor";
 
 export const config: ConfigInterface = {
     namespace: 'ns1',
     redis: {
         //
-        driver: ConfigRedisDriver.IOREDIS,
+        driver: Monitor.RedisDriver.IOREDIS,
         options: {
             host: '127.0.0.1',
             port: 6379,

--- a/types/config.ts
+++ b/types/config.ts
@@ -1,14 +1,9 @@
 import { Monitor } from 'redis-smq-monitor';
 
-export enum ConfigRedisDriver {
-    REDIS = "redis",
-    IOREDIS = "ioredis"
-}
-
 export interface ConfigInterface extends Monitor.ConfigInterface {
     namespace?: string,
     redis: {
-        driver: ConfigRedisDriver,
+        driver: Monitor.RedisDriver,
         options: {
             [key:string]: any
         }


### PR DESCRIPTION
to avoid 'redis' are incompatible error when build